### PR TITLE
fix: hdrReplyListButton double border separator

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -1044,11 +1044,6 @@ global-search-bar {
 		border-color: #1f1f1f !important;
 	}
 
-	#hdrReplyListButton .toolbarbutton-menubutton-button,
-	#hdrReplyListButton .toolbarbutton-menubutton-dropmarker {
-		box-sizing: border-box !important;
-	}
-
 	/* Filter and display button icons — dark variants */
 	#threadPaneQuickFilterButton {
 		background-image: url("Icons/filter-dark.svg") !important;

--- a/userChrome.css
+++ b/userChrome.css
@@ -644,7 +644,6 @@ tree-view[data-show-grouped-by-sort="true"] .card-layout.children *:hover {
 
 #hdrReplyListButton .toolbarbutton-menubutton-button,
 #hdrReplyListButton .toolbarbutton-menubutton-dropmarker {
-	border: 1px solid #ececee !important;
 	box-sizing: border-box !important;
 }
 
@@ -1047,7 +1046,6 @@ global-search-bar {
 
 	#hdrReplyListButton .toolbarbutton-menubutton-button,
 	#hdrReplyListButton .toolbarbutton-menubutton-dropmarker {
-		border: 1px solid #1f1f1f !important;
 		box-sizing: border-box !important;
 	}
 


### PR DESCRIPTION
Fix for the borders of hdrReplyListButton. Before, there was a double border, making the separator bigger. Reply to all button was not affected.